### PR TITLE
Update cargo.toml + println text on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discord-help-bot"
 authors = ["Mohan Chimata <mohanchimata16@gmail.com>"]
 version = "0.1.0"
-edition = "2021"
+edition = "2022"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ impl EventHandler for Handler {
     }
 
     async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
+        println!("{} has started up!", ready.user.name);
     }
 }
 


### PR DESCRIPTION
Hey! Nice repo with Rust.

I have in this PR updated the cargo.toml file because it had a invalid 2021 year and it should be 2022, and updated printed console text upon startup to possibly be more easier to understand, and this text fixed a grammar error.